### PR TITLE
Update to 5.10.17, fedora:latest, and install mongo-org-server RPM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:27
+FROM fedora:latest
 
 MAINTAINER "Joe Doss <joe@solidadmin.com>"
 
-ARG UNIFI_VERSION=5.10.5-6ba4d1bfe5
+ARG UNIFI_VERSION=5.10.17
 ENV UNIFI_VERSION=${UNIFI_VERSION}
 
 ARG UNIFI_UID=1000
@@ -12,7 +12,8 @@ ARG JVM_MAX_HEAP_SIZE=1024m
 ENV JVM_MAX_HEAP_SIZE=${JVM_MAX_HEAP_SIZE}
 
 RUN dnf -y update && \
-    dnf install -y java-1.8.0-openjdk mongodb-server wget unzip && \
+    dnf install -y java-1.8.0-openjdk wget unzip && \
+    dnf install -y https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/RPMS/mongodb-org-server-3.4.9-1.el7.x86_64.rpm && \
     dnf clean all -y
 
 RUN wget https://dl.ubnt.com/unifi/${UNIFI_VERSION}/UniFi.unix.zip -O /tmp/UniFi.unix.zip && \

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ sudo systemctl disable firewalld
 ### Build From GitHub
 
 ```
-sudo podman build --build-arg UNIFI_VERSION=5.10.5-6ba4d1bfe5 \
+sudo podman build --build-arg UNIFI_VERSION=5.10.17 \
     --build-arg UNIFI_UID=$(id -u unifi) \
-    -t unifi:5.10.5-6ba4d1bfe5 git://github.com/jdoss/unifi
+    -t unifi:5.10.17 git://github.com/jdoss/unifi
 ```
 
 ### Build Locally
@@ -35,23 +35,23 @@ sudo podman build --build-arg UNIFI_VERSION=5.10.5-6ba4d1bfe5 \
 ```
 git clone https://github.com/jdoss/unifi
 cd unifi
-sudo podman build --build-arg UNIFI_VERSION=5.10.5-6ba4d1bfe5 \
+sudo podman build --build-arg UNIFI_VERSION=5.10.17 \
     --build-arg UNIFI_UID=$(id -u unifi) \
-    -t unifi:5.10.5-6ba4d1bfe5 .
+    -t unifi:5.10.17 .
 ```
 
 ### Run the Ubiquiti Networks Unifi Controller
 
 ```
 sudo podman run -d --cap-drop ALL -e UNIFI_UID=$(id -u unifi) \
-  -e UNIFI_VERSION=5.10.5-6ba4d1bfe5 \
+  -e UNIFI_VERSION=5.10.17 \
   -e JVM_MAX_HEAP_SIZE=1024m \
   -e TZ='America/Chicago' \
   -p 3478:3478/udp -p 8080:8080/tcp -p 8443:8443/tcp -p 8843:8843/tcp -p 10001:10001/udp \
   -v /opt/unifi/data:/opt/unifi/data:Z \
   -v /opt/unifi/logs:/opt/unifi/logs:Z \
   -v /opt/unifi/run:/opt/unifi/run:Z \
-  --name unifi localhost/unifi:5.10.5-6ba4d1bfe5
+  --name unifi localhost/unifi:5.10.17
 ```
 
 ## License


### PR DESCRIPTION
This PR updates the controller software to 5.10.17, uses `fedora:latest` and uses the mongo-org-server RPM since Red Hat is dropping MongoDB from it's repos due to licensing reasons. 